### PR TITLE
support BAMs with >65535 CIGAR operators

### DIFF
--- a/src/samtools/bam.c
+++ b/src/samtools/bam.c
@@ -188,19 +188,25 @@ static void swap_endian_data(const bam1_core_t *c, int data_len, uint8_t *data)
 	}
 }
 
+static inline uint32_t le_to_u32(const uint8_t *buf)
+{
+	return (uint32_t)buf[0] | (uint32_t)buf[1] << 8 | (uint32_t)buf[2] << 16 | (uint32_t)buf[3] << 24;
+}
+
 int bam_tag2cigar(bam1_t *b)
 {
 	bam1_core_t *c = &b->core;
-	uint32_t cigar_st, n_cigar4, CG_st, CG_en, ori_len = b->data_len, *cigar0, CG_len;
+	uint32_t cigar_st, n_cigar4, CG_st, CG_en, ori_len = b->data_len, *cigar0, CG_len, fake_bytes;
 	uint8_t *CG;
 
 	// test where there is a real CIGAR in the CG tag to move
-	if (c->n_cigar != 1 || c->tid < 0 || c->pos < 0) return 0;
+	if (c->n_cigar == 0 || c->tid < 0 || c->pos < 0) return 0;
 	cigar0 = bam1_cigar(b);
 	if (bam_cigar_op(cigar0[0]) != BAM_CSOFT_CLIP || bam_cigar_oplen(cigar0[0]) != c->l_qseq) return 0;
+	fake_bytes = c->n_cigar * 4;
 	if ((CG = bam_aux_get(b, "CG")) == 0) return 0; // no CG tag
 	if (CG[0] != 'B' || CG[1] != 'I') return 0; // not of type B,I
-	CG_len = *(uint32_t*)(CG + 2);
+	CG_len = le_to_u32(CG + 2);
 	if (CG_len == 0) return 0; // nothing to move
 
 	// move from the CG tag to the right position
@@ -209,16 +215,16 @@ int bam_tag2cigar(bam1_t *b)
 	n_cigar4 = c->n_cigar * 4;
 	CG_st = CG - b->data - 2;
 	CG_en = CG_st + 8 + n_cigar4;
-	b->data_len += n_cigar4 - 4; // we need (c->n_cigar-1)*4 bytes to swap CIGAR to the right place
+	b->data_len += n_cigar4 - fake_bytes; // we need c->n_cigar*4-fake_bytes bytes to swap CIGAR to the right place
 	if (b->m_data < b->data_len) {
 		b->m_data = b->data_len;
 		kroundup32(b->m_data);
 		b->data = (uint8_t*)realloc(b->data, b->m_data);
 	}
-	memmove(b->data + cigar_st + n_cigar4, b->data + cigar_st + 4, ori_len - (cigar_st + 4)); // insert 4*(c->n_cigar-1) empty space to make room
-	memcpy(b->data + cigar_st, b->data + (n_cigar4 - 4) + CG_st + 8, n_cigar4); // copy the real CIGAR to the right place; -4 for the fake CIGAR
+	memmove(b->data + cigar_st + n_cigar4, b->data + cigar_st + fake_bytes, ori_len - (cigar_st + fake_bytes)); // insert 4*c->n_cigar-fake_bytes empty space to make room
+	memcpy(b->data + cigar_st, b->data + (n_cigar4 - fake_bytes) + CG_st + 8, n_cigar4); // copy the real CIGAR to the right place
 	if (ori_len > CG_en) // move data after the CG tag
-		memmove(b->data + CG_st + n_cigar4 - 4, b->data + CG_en + n_cigar4 - 4, ori_len - CG_en);
+		memmove(b->data + CG_st + n_cigar4 - fake_bytes, b->data + CG_en + n_cigar4 - fake_bytes, ori_len - CG_en);
 	b->data_len -= n_cigar4 + 8; // 8: CGBI (4 bytes) and CGBI length (4)
 	b->core.bin = bam_reg2bin(b->core.pos, bam_calend(&b->core, bam1_cigar(b)));
 	return 1;
@@ -270,11 +276,11 @@ inline int bam_write1_core(bamFile fp, const bam1_core_t *c, int data_len, uint8
 	uint32_t x[8], block_len = data_len + BAM_CORE_SIZE, y;
 	int i;
 	assert(BAM_CORE_SIZE == 32);
-	if (c->n_cigar > 0xffff) block_len += 12;
+	if (c->n_cigar > 0xffff) block_len += 16; // 4*2 for fake cigar; 4 for CG:B,I; 4 for real CIGAR length
 	x[0] = c->tid;
 	x[1] = c->pos;
 	x[2] = (uint32_t)c->bin<<16 | c->qual<<8 | c->l_qname;
-	if (c->n_cigar > 0xffff) x[3] = (uint32_t)c->flag<<16 | 1;
+	if (c->n_cigar > 0xffff) x[3] = (uint32_t)c->flag << 16 | 2;
 	else x[3] = (uint32_t)c->flag<<16 | c->n_cigar;
 	x[4] = c->l_qseq;
 	x[5] = c->mtid;
@@ -292,12 +298,14 @@ inline int bam_write1_core(bamFile fp, const bam1_core_t *c, int data_len, uint8
 		bam_write(fp, data, data_len);
 	} else {
 		uint8_t buf[4];
-		uint32_t cigar_st, cigar_en, cigar1;
+		uint32_t cigar_st, cigar_en, cigar[2];
 		cigar_st = c->l_qname;
 		cigar_en = cigar_st + c->n_cigar * 4;
-		cigar1 = (uint32_t)c->l_qseq << 4 | BAM_CSOFT_CLIP;
+		cigar[0] = (uint32_t)c->l_qseq << 4 | BAM_CSOFT_CLIP;
+		cigar[1] = (uint32_t)(bam_calend(c, (uint32_t*)(data + c->l_qname)) - c->pos) << 4 | BAM_CREF_SKIP;
 		bam_write(fp, data, c->l_qname); // write data before cigar
-		bam_write(fp, u32_to_le(cigar1, buf), 4); // write cigar: <read_length>S
+		bam_write(fp, u32_to_le(cigar[0], buf), 4); // write cigar: <read_length>S
+		bam_write(fp, u32_to_le(cigar[1], buf), 4); // write cigar: <ref_aln_length>N
 		bam_write(fp, &data[cigar_en], data_len - cigar_en); // write data after CIGAR
 		bam_write(fp, "CGBI", 4); // write CG:B,I
 		bam_write(fp, u32_to_le(c->n_cigar, buf), 4); // write the true CIGAR length

--- a/src/samtools/bam.h
+++ b/src/samtools/bam.h
@@ -179,7 +179,8 @@ typedef struct {
 	int32_t tid;
 	int32_t pos;
 	uint32_t bin:16, qual:8, l_qname:8;
-	uint32_t flag:16, n_cigar:16;
+	uint32_t flag;
+	uint32_t n_cigar;
 	int32_t l_qseq;
 	int32_t mtid;
 	int32_t mpos;
@@ -686,6 +687,8 @@ extern "C" {
 	int bam_aux_del(bam1_t *b, uint8_t *s);
 	void bam_aux_append(bam1_t *b, const char tag[2], char type, int len, uint8_t *data);
 	uint8_t *bam_aux_get_core(bam1_t *b, const char tag[2]); // an alias of bam_aux_get()
+
+	int bam_tag2cigar(bam1_t *b);
 
 
 	/*****************

--- a/src/samtools/bam_import.c
+++ b/src/samtools/bam_import.c
@@ -465,6 +465,7 @@ int sam_read1(tamFile fp, bam_header_t *header, bam1_t *b)
 	b->l_aux = doff - doff0;
 	b->data_len = doff;
 	if (bam_no_B) bam_remove_B(b);
+	bam_tag2cigar(b);
 	return z;
 }
 


### PR DESCRIPTION
This PR enlarges `bam1_core_t::n_cigar` to 32 bits. It is a necessary ABI change to hold cigars longer than 65535 in memory. For typical BAM records, the PR changes nothing. For a record with >65535 cigar operators:

* When writing SAM, the PR has no effect. SAM naturally works with long cigars.

* When writing BAM to disk, the PR writes a fake cigar `<readLength>S` at the original cigar position and puts the real cigar at the `CG:B,I` (binary array type) at the end.

* When reading from BAM into memory, the PR calls `bam_tag2cigar()` to move the real cigar back to the right position.

* When reading from SAM into memory: a) if SAM uses real cigar, read normally; b) if SAM puts the real cigar at the CG tag (e.g. output by `minimap2 -L` or generated by older tools unaware of the CG tag), the PR reads normally and then moves the real cigar back with `bam_tag2cigar()`.

To endusers and most developers, these operations are seamless. They won't notice the existence of the CG tag. All APIs stay the same, too.

I am not familiar with the bioc build system, so I have not tested the code on real data. Nonetheless, this PR is very close to the change to htslib. It should not have big issues, I believe. You can find sample files [here](http://lh3lh3.users.sourceforge.net/data/cigar-64k/). Your help on testing will be much appreciated. By the way, the precompiled samtools binary there already supports long cigars. It may help testing.