### PR TITLE
Bump version to avoid overwriting CRAM support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: Rsamtools
 Type: Package
 Title: Binary alignment (BAM), FASTA, variant call (BCF), and tabix
     file import
-Version: 2.5.3
+Version: 2.99.9
 Author: Martin Morgan, Herv\'e Pag\`es, Valerie Obenchain, Nathaniel
     Hayden
 Maintainer: Bioconductor Package Maintainer


### PR DESCRIPTION
Users of `spiky` often find that RELEASE and DEVEL bumps overwrite their CRAM support.

This patch fixes the issue and should not affect other (non-CRAM) users.