### PR TITLE
add nThreads and byTag options to sortBam

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ biocViews: DataImport,  Sequencing, Coverage, Alignment, QualityControl
 URL: https://bioconductor.org/packages/Rsamtools
 Video: https://www.youtube.com/watch?v=Rfon-DQYbWA&list=UUqaMSQd_h-2EDGsU6WDiX0Q
 BugReports: https://github.com/Bioconductor/Rsamtools/issues
-Version: 2.15.0
+Version: 2.15.1
 License: Artistic-2.0 | file LICENSE
 Encoding: UTF-8
 Author: Martin Morgan, Hervé Pagès, Valerie Obenchain, Nathaniel

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+CHANGES IN VERSION 2.16
+-----------------------
+
+NEW FEATURES
+
+    o (v 2.15.1) sortBam() gains support for sorting by tag (byTag) and using
+      multiple threads (nThreads). (See
+      https://github.com/Bioconductor/Rsamtools/issues/46. ; kriemo)
+
 CHANGES IN VERSION 2.10
 -----------------------
 

--- a/R/methods-BamFile.R
+++ b/R/methods-BamFile.R
@@ -410,10 +410,12 @@ setMethod(indexBam, "BamFile", function(files, ...) {
 })
 
 setMethod(sortBam, "BamFile",
-    function(file, destination, ..., byQname=FALSE, maxMemory=512)
+    function(file, destination, ..., byQname=FALSE, maxMemory=512,
+             byTag=NULL, nThreads=1L)
 {
     sortBam(path(file), destination, ...,
-                byQname=byQname, maxMemory=maxMemory)
+            byQname=byQname, maxMemory=maxMemory,
+            byTag=byTag, nThreads=nThreads)
 })
 
 

--- a/R/sortBam.R
+++ b/R/sortBam.R
@@ -1,11 +1,11 @@
 setMethod(sortBam, "character",
           function(file, destination, ...,
-                   byQname=FALSE, maxMemory=512)
+                   byQname=FALSE, maxMemory=512, byTag=NULL, nThreads=1L)
 {
     file <- .normalizePath(file)
     destination <- .normalizePath(destination)
     result <- .Call(.sort_bam, file, destination, byQname,
-                    as.integer(maxMemory))
+                    as.integer(maxMemory), byTag, as.integer(nThreads))
     destination <- paste(result, "bam", sep=".")
     if (!file.exists(destination)) {
         msg <- sprintf("'sortBam' failed to create destination '%s'",

--- a/inst/unitTests/test_sortBam_test.R
+++ b/inst/unitTests/test_sortBam_test.R
@@ -17,3 +17,31 @@ test_sortBam_not_BAM_input <- function() {
     fl0 <- system.file("extdata", "ex1.sam", package="Rsamtools")
     checkException(sortBam(fl0, tempfile()), silent=TRUE)
 }
+
+test_sortBam_byTag <- function() {
+  src <- system.file("unitTests", "cases", package="Rsamtools")
+  fl <- file.path(src, "ex1_unsort.bam")
+  ofl <- tempfile()
+  checkTrue(file.create(ofl))
+  on.exit(unlink(ofl))
+
+  # sort by integer Tag Aq
+  sorted <- sortBam(fl, ofl, byTag = "Aq")
+  obs <- scanBam(sorted, param = ScanBamParam(tag = "Aq"))[[1]]
+  tVal <- obs$tag$Aq
+
+  # reads without Aq tag are first records in sorted bam
+  checkIdentical(which(is.na(tVal)), 1L:36L)
+  validTags <- tVal[!is.na(tVal)]
+  checkIdentical(validTags, sort(validTags))
+
+  checkException(sortBam(fl, ofl, byTag = 1), silent=TRUE)
+  checkException(sortBam(fl, ofl, byTag = c("bogus", "input")), silent=TRUE)
+}
+
+test_sortBam_nThreads <- function() {
+  src <- system.file("unitTests", "cases", package="Rsamtools")
+  fl <- file.path(src, "ex1_unsort.bam")
+  checkException(sortBam(fl, tempfile(), nThreads = 0), silent=TRUE)
+  checkException(sortBam(fl, tempfile(), nThreads = c(0, 1)), silent=TRUE)
+}

--- a/man/BamFile-class.Rd
+++ b/man/BamFile-class.Rd
@@ -103,7 +103,7 @@ qnameSuffixStart(object, ...) <- value
     filter=FilterRules(), indexDestination=TRUE,
     param=ScanBamParam(what=scanBamWhat()))
 \S4method{indexBam}{BamFile}(files, ...)
-\S4method{sortBam}{BamFile}(file, destination, ..., byQname=FALSE, maxMemory=512)
+\S4method{sortBam}{BamFile}(file, destination, ..., byQname=FALSE, maxMemory=512, byTag=NULL, nThreads=1L)
 \S4method{mergeBam}{BamFileList}(files, destination, ...)
 
 ## reading
@@ -188,7 +188,7 @@ qnameSuffixStart(object, ...) <- value
     \item{indexDestination}{logical(1) indicating whether the destination
       file should also be indexed.}
 
-    \item{byQname, maxMemory}{See \code{\link{sortBam}}.}
+    \item{byQname, maxMemory, byTag, nThreads}{See \code{\link{sortBam}}.}
 
     \item{param}{An optional \code{\linkS4class{ScanBamParam}} instance to
        further influence scanning, counting, or filtering.}

--- a/man/scanBam.Rd
+++ b/man/scanBam.Rd
@@ -59,7 +59,8 @@ filterBam(file, destination, index=file, ...)
     param=ScanBamParam(what=scanBamWhat()))
     
 sortBam(file, destination, ...)
-\S4method{sortBam}{character}(file, destination, ..., byQname=FALSE, maxMemory=512)
+\S4method{sortBam}{character}(file, destination, ..., byQname=FALSE,
+    maxMemory=512, byTag=NULL, nThreads=1L)
 
 indexBam(files, ...)
 \S4method{indexBam}{character}(files, ...)
@@ -117,6 +118,12 @@ mergeBam(files, destination, ...)
  
   \item{maxMemory}{A numerical(1) indicating the maximal amount of
     memory (in MB) that the function is allowed to use.}
+
+  \item{byTag}{A character(1) indicating whether the BAM file should be
+    sorted by the supplied tag value.}
+
+  \item{nThreads}{An integer(1) indicating the number of threads the function
+    should use.}
 
   \item{param}{An instance of \code{\linkS4class{ScanBamParam}}. This
     influences what fields and which records are imported.}

--- a/src/R_init_Rsamtools.c
+++ b/src/R_init_Rsamtools.c
@@ -36,7 +36,7 @@ static const R_CallMethodDef callMethods[] = {
     /* io_sam.c */
     {".scan_bam_template", (DL_FUNC) & scan_bam_template, 2},
     {".scan_bam_cleanup", (DL_FUNC) & scan_bam_cleanup, 0},
-    {".sort_bam", (DL_FUNC) & sort_bam, 4},
+    {".sort_bam", (DL_FUNC) & sort_bam, 6},
     {".merge_bam", (DL_FUNC) & merge_bam, 8},
     {".index_bam", (DL_FUNC) & index_bam, 1},
     /* bcffile.c */

--- a/src/io_sam.h
+++ b/src/io_sam.h
@@ -10,7 +10,7 @@ extern "C" {
 
 SEXP scan_bam_template(SEXP rname, SEXP tags);
 SEXP sort_bam(SEXP fname, SEXP destinationPrefix, SEXP isByQname,
-              SEXP maxMemory);
+              SEXP maxMemory, SEXP byTag, SEXP nThreads);
 SEXP merge_bam(SEXP fnames, SEXP destination, SEXP overwrite,
                SEXP hname, SEXP regionStr, SEXP isByQname,
                SEXP addRG, SEXP compressLevel1);


### PR DESCRIPTION
This PR adds two additional options to `sortBam()` which are provided by `samtools sort` on the command line.  
- `byTag` exposes an option to sort by a tag rather than by position or QNAME.  
- `nThreads` exposes an option to use more than one thread during sorting. 

related to #46 