### PR TITLE
Add code of conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+The Bioconductor community values
+
+* an open approach to science that promotes the sharing of ideas, code, and expertise
+* collaboration
+* diversity and inclusivity
+* a kind and welcoming environment
+* community contributions
+
+In line with these values, Bioconductor is dedicated to providing a welcoming, supportive, collegial, experience free of harassment, intimidation, and bullying regardless of:
+
+* identity: gender, gender identity and expression, sexual orientation, disability, physical appearance, ethnicity, body size, race, age, religion, etc.
+* intellectual position: approaches to data analysis, software preferences, coding style, scientific perspective, etc.
+* stage of career
+
+In order to uphold these values, members of the Bioconductor community are required to follow the Code of Conduct.The latest version of Bioconductor project Code of Conduct is available at http://bioconductor.org/about/code-of-conduct/. Please read the Code of Conduct before contributing to this project.
+
+Thank you!

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ biocViews: DataImport,  Sequencing, Coverage, Alignment, QualityControl
 URL: https://bioconductor.org/packages/Rsamtools
 Video: https://www.youtube.com/watch?v=Rfon-DQYbWA&list=UUqaMSQd_h-2EDGsU6WDiX0Q
 BugReports: https://github.com/Bioconductor/Rsamtools/issues
-Version: 2.17.0
+Version: 2.17.1
 License: Artistic-2.0 | file LICENSE
 Encoding: UTF-8
 Authors@R: c(

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+CHANGES IN VERSION 2.17.1
+
+NEW FEATURES
+
+    o (v 2.17.1) Implemented rworkflows.
+    o (v 2.17.1) Added Bioc Code of Conduct.
+
 CHANGES IN VERSION 2.16
 -----------------------
 


### PR DESCRIPTION
It may be worthwhile to add the Bioconductor Code of Conduct to this repo.
Created using `biocthis::use_bioc_coc()`.